### PR TITLE
Editing the mention should trigger the typeahead again

### DIFF
--- a/Hakawai.podspec
+++ b/Hakawai.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Hakawai"
-  s.version      = "7.1.2"
+  s.version      = "7.1.3"
   s.summary      = "Hakawai aims to be a more powerful UITextView."
   s.description  = <<-DESC
                    Hakawai is a subclass of UITextView that exposes a number of convenience APIs, and supports further extension via 'plug-ins'. Hakawai ships with an easy-to-use, powerful, and customizable plug-in allowing users to create social media 'mentions'-style annotations.
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => "Apache License, Version 2.0", :file => "LICENSE" }
   s.authors      = "Austin Zheng"
   s.platform = :ios, "10.0"
-  s.source       = { :git => "https://github.com/linkedin/Hakawai.git", :tag => "7.1.2" }
+  s.source       = { :git => "https://github.com/linkedin/Hakawai.git", :tag => "7.1.3" }
   s.framework  = "UIKit"
   s.requires_arc = true
 end

--- a/Hakawai.podspec
+++ b/Hakawai.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Hakawai"
-  s.version      = "7.1.4"
+  s.version      = "7.1.5"
   s.summary      = "Hakawai aims to be a more powerful UITextView."
   s.description  = <<-DESC
                    Hakawai is a subclass of UITextView that exposes a number of convenience APIs, and supports further extension via 'plug-ins'. Hakawai ships with an easy-to-use, powerful, and customizable plug-in allowing users to create social media 'mentions'-style annotations.
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => "Apache License, Version 2.0", :file => "LICENSE" }
   s.authors      = "Austin Zheng"
   s.platform = :ios, "10.0"
-  s.source       = { :git => "https://github.com/linkedin/Hakawai.git", :tag => "7.1.4" }
+  s.source       = { :git => "https://github.com/linkedin/Hakawai.git", :tag => "7.1.5" }
   s.framework  = "UIKit"
   s.requires_arc = true
 end

--- a/Hakawai.podspec
+++ b/Hakawai.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Hakawai"
-  s.version      = "7.1.3"
+  s.version      = "7.1.4"
   s.summary      = "Hakawai aims to be a more powerful UITextView."
   s.description  = <<-DESC
                    Hakawai is a subclass of UITextView that exposes a number of convenience APIs, and supports further extension via 'plug-ins'. Hakawai ships with an easy-to-use, powerful, and customizable plug-in allowing users to create social media 'mentions'-style annotations.
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => "Apache License, Version 2.0", :file => "LICENSE" }
   s.authors      = "Austin Zheng"
   s.platform = :ios, "10.0"
-  s.source       = { :git => "https://github.com/linkedin/Hakawai.git", :tag => "7.1.3" }
+  s.source       = { :git => "https://github.com/linkedin/Hakawai.git", :tag => "7.1.4" }
   s.framework  = "UIKit"
   s.requires_arc = true
 end

--- a/Hakawai/Core/HKWControlFlowPluginProtocols.h
+++ b/Hakawai/Core/HKWControlFlowPluginProtocols.h
@@ -47,6 +47,12 @@
  */
 -(void) textViewDidProgrammaticallyUpdate:(UITextView *)textView;
 
+/*!
+ The new delegate method that's used in the Korean Mentions fix case. Mimics most of the functionality of the current override
+ for the Apple-provided method, with differences in deletion and insertion because it's being called via the NSTextStorageDelegate
+ */
+- (void)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text isInsertion:(BOOL)isInsertion;
+
 @end
 
 @protocol HKWAbstractionLayerControlFlowPluginProtocol <HKWAbstractionLayerDelegate, HKWSimplePluginProtocol>

--- a/Hakawai/Core/HKWControlFlowPluginProtocols.h
+++ b/Hakawai/Core/HKWControlFlowPluginProtocols.h
@@ -51,7 +51,11 @@
  The new delegate method that's used in the Korean Mentions fix case. Mimics most of the functionality of the current override
  for the Apple-provided method, with differences in deletion and insertion because it's being called via the NSTextStorageDelegate
  */
-- (void)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text isInsertion:(BOOL)isInsertion;
+- (void)textView:(UITextView *)textView
+shouldChangeTextInRange:(NSRange)range
+      changeText:(NSString *)text
+     isInsertion:(BOOL)isInsertion
+  previousLength:(NSUInteger)previousLength;
 
 @end
 

--- a/Hakawai/Core/HKWTextView+Plugins.m
+++ b/Hakawai/Core/HKWTextView+Plugins.m
@@ -176,7 +176,14 @@ typedef NS_ENUM(NSInteger, HKWCycleFirstResponderMode) {
     // Reset viewport to original value
     __strong __auto_type externalDelegate = self.externalDelegate;
     if ([externalDelegate respondsToSelector:@selector(textViewDidExitSingleLineViewportMode:)]) {
-        [externalDelegate textViewDidExitSingleLineViewportMode:self];
+        if (HKWTextView.enableKoreanMentionsFix) {
+            // With the korean mentions fix we have to make sure this call is made on the main thread since it may originate from the text storage delegate
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [externalDelegate textViewDidExitSingleLineViewportMode:self];
+            });
+        } else {
+            [externalDelegate textViewDidExitSingleLineViewportMode:self];
+        }
     }
     [self setContentOffset:self.originalContentOffset animated:NO];
 }

--- a/Hakawai/Core/HKWTextView.h
+++ b/Hakawai/Core/HKWTextView.h
@@ -126,6 +126,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readonly) BOOL inSingleLineViewportMode;
 
+/*!
+ String that saves the state of the text in the text view so that it can be accessed in the NSTextStorageDelegate, which will
+ already have deleted the character by the time it's trying to process said deletion
+ */
+@property (nonatomic, strong, readonly) NSString *textStateBeforeDeletion;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Hakawai/Core/HKWTextView.h
+++ b/Hakawai/Core/HKWTextView.h
@@ -44,6 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL) enableExperimentalDeadLockFix;
 + (BOOL) enableKoreanMentionsFix;
 + (void) setEnableExperimentalDeadLockFix:(BOOL)enabled;
++ (void) setEnableKoreanMentionsFix:(BOOL)enabled;
 
 #pragma mark - Initialization
 

--- a/Hakawai/Core/HKWTextView.h
+++ b/Hakawai/Core/HKWTextView.h
@@ -42,6 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface HKWTextView : UITextView
 
 + (BOOL) enableExperimentalDeadLockFix;
++ (BOOL) enableKoreanMentionsFix;
 + (void) setEnableExperimentalDeadLockFix:(BOOL)enabled;
 
 #pragma mark - Initialization

--- a/Hakawai/Core/HKWTextView.h
+++ b/Hakawai/Core/HKWTextView.h
@@ -43,8 +43,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BOOL) enableExperimentalDeadLockFix;
 + (BOOL) enableKoreanMentionsFix;
++ (BOOL) enableMentionSelectFix;
 + (void) setEnableExperimentalDeadLockFix:(BOOL)enabled;
 + (void) setEnableKoreanMentionsFix:(BOOL)enabled;
++ (void) setEnableMentionSelectFix:(BOOL)enabled;
 
 #pragma mark - Initialization
 

--- a/Hakawai/Core/HKWTextView.m
+++ b/Hakawai/Core/HKWTextView.m
@@ -24,10 +24,7 @@
 @interface HKWTextView () <UITextViewDelegate, HKWAbstractionLayerDelegate, NSTextStorageDelegate>
 
 @property (nonatomic) NSMutableDictionary *simplePluginsDictionary;
-/*!
- String that saves the state of the text in the text view so that it can be accessed in the NSTextStorageDelegate, which will
- already have deleted the character by the time it's trying to process said deletion
- */
+
 @property (nonatomic, strong, readwrite) NSString *textStateBeforeDeletion;
 
 @end

--- a/Hakawai/Core/HKWTextView.m
+++ b/Hakawai/Core/HKWTextView.m
@@ -140,11 +140,13 @@ static BOOL enableKoreanMentionsFix = NO;
     if (delta > 0) {
         // If the delta is greater than 0, this is an insertion
         NSString *change = [self.text substringWithRange:editedRange];
-        [self.controlFlowPlugin textView:self
-                 shouldChangeTextInRange:editedRange
-                              changeText:change
-                             isInsertion:true
-                          previousLength:self.textStateBeforeDeletion.length];
+        if ([self.controlFlowPlugin respondsToSelector:@selector(textView:shouldChangeTextInRange:changeText:isInsertion:previousLength:)]) {
+            [self.controlFlowPlugin textView:self
+                     shouldChangeTextInRange:editedRange
+                                  changeText:change
+                                 isInsertion:true
+                              previousLength:self.textStateBeforeDeletion.length];
+        }
         // Update the saved text state so that it can be accessed in the case of deletion
         if (self.textStateBeforeDeletion == nil) {
             self.textStateBeforeDeletion = change;
@@ -162,11 +164,13 @@ static BOOL enableKoreanMentionsFix = NO;
         // Retrieve the string to delete
         NSRange range = NSMakeRange(editedRange.location, absoluteDelta);
         NSString *toDelete = [self.textStateBeforeDeletion substringWithRange:range];
-        [self.controlFlowPlugin textView:self
-                 shouldChangeTextInRange:range
-                              changeText:toDelete
-                             isInsertion:false
-                          previousLength:self.textStateBeforeDeletion.length];
+        if ([self.controlFlowPlugin respondsToSelector:@selector(textView:shouldChangeTextInRange:changeText:isInsertion:previousLength:)]) {
+            [self.controlFlowPlugin textView:self
+                     shouldChangeTextInRange:range
+                                  changeText:toDelete
+                                 isInsertion:false
+                              previousLength:self.textStateBeforeDeletion.length];
+        }
         // Update the text state for the deletion
         self.textStateBeforeDeletion = [self.textStateBeforeDeletion stringByReplacingCharactersInRange:range withString:@""];
     }

--- a/Hakawai/Core/HKWTextView.m
+++ b/Hakawai/Core/HKWTextView.m
@@ -34,6 +34,7 @@
 
 static BOOL enableExperimentalDeadLockFix = NO;
 static BOOL enableKoreanMentionsFix = NO;
+static BOOL enableMentionSelectFix = NO;
 
 @implementation HKWTextView
 
@@ -49,6 +50,13 @@ static BOOL enableKoreanMentionsFix = NO;
 }
 + (void)setEnableKoreanMentionsFix:(BOOL)enabled {
     enableKoreanMentionsFix = enabled;
+}
+
++ (BOOL)enableMentionSelectFix {
+    return enableMentionSelectFix;
+}
++ (void)setEnableMentionSelectFix:(BOOL)enabled {
+    enableMentionSelectFix = enabled;
 }
 
 #pragma mark - Lifecycle

--- a/Hakawai/Core/HKWTextView.m
+++ b/Hakawai/Core/HKWTextView.m
@@ -149,7 +149,10 @@ static BOOL enableKoreanMentionsFix = NO;
         if (self.textStateBeforeDeletion == nil) {
             self.textStateBeforeDeletion = change;
         } else {
-            [self padTexStorageForRangeInsertionAtLocation:editedRange.location ofLength:delta];
+            // This line is needed because text storage works by replacing a certiain number of characters in a given range.
+            // In order to have the correct number of characters to replace in our text state string, we pad it at the correct location
+            // with the given delta.
+            [self padTextStorageForRangeInsertionAtLocation:editedRange.location withLength:delta];
             self.textStateBeforeDeletion = [self.textStateBeforeDeletion stringByReplacingCharactersInRange:editedRange withString:change];
         }
     }
@@ -765,10 +768,14 @@ static BOOL enableKoreanMentionsFix = NO;
     return _touchCaptureOverlayView;
 }
 
-- (void)padTexStorageForRangeInsertionAtLocation:(NSUInteger)location ofLength:(NSInteger)length {
+/**
+ Adds padding of a given @c length at a given @c location, to make string replacement in the text storage delegate work correctly
+ */
+- (void)padTextStorageForRangeInsertionAtLocation:(NSUInteger)location withLength:(NSInteger)length {
     NSString *string = @"";
-    for (int i = 0; i < length; i++)
+    for (int i = 0; i < length; i++) {
         string = [string stringByAppendingString:@" "];
+    }
     self.textStateBeforeDeletion = [self.textStateBeforeDeletion stringByReplacingCharactersInRange:NSMakeRange(location, 0) withString:string];
 }
 

--- a/Hakawai/Core/HKWTextView.m
+++ b/Hakawai/Core/HKWTextView.m
@@ -26,6 +26,7 @@
 @end
 
 static BOOL enableExperimentalDeadLockFix = NO;
+static BOOL enableKoreanMentionsFix = NO;
 
 @implementation HKWTextView
 
@@ -34,6 +35,13 @@ static BOOL enableExperimentalDeadLockFix = NO;
 }
 + (void)setEnableExperimentalDeadLockFix:(BOOL)enabled {
     enableExperimentalDeadLockFix = enabled;
+}
+
++ (BOOL)enableKoreanMentionsFix {
+    return enableKoreanMentionsFix;
+}
++ (void)setEnableKoreanMentionsFix:(BOOL)enabled {
+    enableKoreanMentionsFix = enabled;
 }
 
 #pragma mark - Lifecycle

--- a/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
@@ -270,9 +270,14 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
 
     __strong __auto_type delegate = self.delegate;
 
+    /**
+     For cases when mentions is triggered when whitespace between control character and word is deleted,
+     for example "@|John"('|'represents cursor), string buffer is not empty but mentions has to stop when control character is deleted.
+     Using isControlCharacterDeleted flag to decide control character deletion for such case.
+     */
     BOOL isControlCharacterDeleted = NO;
     if (deleteString.length == 1
-        &&[deleteString containsString:[NSString stringWithFormat:@"%C", self.explicitSearchControlCharacter]]
+        && [deleteString containsString:[NSString stringWithFormat:@"%C", self.explicitSearchControlCharacter]]
         && self.stringBuffer.length > 0
         && [self.stringBuffer characterAtIndex:self.stringBuffer.length - 1] != self.explicitSearchControlCharacter) {
         isControlCharacterDeleted = YES;

--- a/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
@@ -165,9 +165,8 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
             }
     }
     // When whitespace is typed during mention creation state and previous character is control character
-    // then mention creation should be ended. e.g "@@ " will stop mention current creation.
-    const BOOL shouldCreateNewMentionState = previousCharacterIsControl && isWhitespace;
-    if (([self.stringBuffer length] == 0 && isWhitespace) || shouldCreateNewMentionState) {
+    // then mention creation should end. e.g "@@ " will stop mention current creation.
+    if (([self.stringBuffer length] == 0 || previousCharacterIsControl) && isWhitespace) {
         self.state = HKWMentionsCreationStateQuiescent;
         [delegate cancelMentionFromStartingLocation:self.startingLocation];
         return;

--- a/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
@@ -164,8 +164,8 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
                 return;
             }
     }
-    // When whitespace is typed during mention creation state and previous char is control character
-    // then metion creation should to stalled. e.g "@@ " will stop mention current creation.
+    // When whitespace is typed during mention creation state and previous character is control character
+    // then mention creation should be ended. e.g "@@ " will stop mention current creation.
     const BOOL shouldCreateNewMentionState = previousCharacterIsControl && isWhitespace;
     if (([self.stringBuffer length] == 0 && isWhitespace) || shouldCreateNewMentionState) {
         self.state = HKWMentionsCreationStateQuiescent;

--- a/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
@@ -927,8 +927,15 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
     mention.metadata = [entity entityMetadata];
     self.state = HKWMentionsCreationStateQuiescent;
     __strong __auto_type delegate = self.delegate;
-    [delegate createMention:mention startingLocation:self.startingLocation];
-    [delegate selected:entity atIndexPath:indexPath];
+
+    if (HKWTextView.enableMentionSelectFix) {
+        // Delegate selected callback should fire prior to creationMention which triggers textView callbacks
+        [delegate selected:entity atIndexPath:indexPath];
+        [delegate createMention:mention startingLocation:self.startingLocation];
+    } else {
+        [delegate createMention:mention startingLocation:self.startingLocation];
+        [delegate selected:entity atIndexPath:indexPath];
+    }
 }
 
 

--- a/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
@@ -239,7 +239,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
     }
 }
 
-- (void)stringDeleted:(NSString *)deleteString isControlCharacterDeleted:(BOOL)isControlCharacterDeleted {
+- (void)stringDeleted:(NSString *)deleteString {
     // State transition
     NSAssert([deleteString length] > 0, @"Logic error: string to be deleted must not be empty.");
 
@@ -269,6 +269,14 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
     }
 
     __strong __auto_type delegate = self.delegate;
+
+    BOOL isControlCharacterDeleted = NO;
+    if (deleteString.length == 1
+        &&[deleteString containsString:[NSString stringWithFormat:@"%C", self.explicitSearchControlCharacter]]
+        && self.stringBuffer.length > 0
+        && [self.stringBuffer characterAtIndex:self.stringBuffer.length - 1] != self.explicitSearchControlCharacter) {
+        isControlCharacterDeleted = YES;
+    }
 
     // Switch on the overall state
     switch (self.state) {

--- a/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
@@ -232,7 +232,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
             else {
                 [self.stringBuffer appendString:string];
                 // Move the state to 'pending request'. This will cause another request to be fired as soon as the
-                //  timer expires.
+                // timer expires.
                 self.networkState = HKWMentionsCreationNetworkStatePendingRequestAfterCooldown;
             }
             break;
@@ -245,7 +245,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
 
     // Whether or not the buffer is empty (no characters to search upon).
     // Note that, if the mention is an explicit mention (use control character), user can back out to beginning. But if
-    //  the mention is implicit, backing out to the beginning will cancel mentions creation.
+    // the mention is implicit, backing out to the beginning will cancel mentions creation.
     BOOL bufferAlreadyEmpty = ([self.stringBuffer length] == 0
                                || (self.searchType == HKWMentionsSearchTypeImplicit
                                    && [self.stringBuffer length] == 1));

--- a/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
@@ -249,7 +249,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
     BOOL bufferAlreadyEmpty = ([self.stringBuffer length] == 0
                                || (self.searchType == HKWMentionsSearchTypeImplicit
                                    && [self.stringBuffer length] == 1));
-    
+
     // The range of the buffer string that corresponds to the delete string (if the delete string is valid)
     NSRange toDeleteRange = NSMakeRange([self.stringBuffer length] - [deleteString length], [deleteString length]);
 
@@ -365,7 +365,9 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
                    usingControlCharacter:(BOOL)usingControlCharacter
                         controlCharacter:(unichar)character
                                 location:(NSUInteger)location {
-    if (self.networkState != HKWMentionsCreationNetworkStateQuiescent) {
+    // Because we are supporting insertion of strings (including valid mention-strings) via non-english keyboards,
+    // we should be able to start a new mention even without being in a quiescent state
+    if (!HKWTextView.enableKoreanMentionsFix && self.networkState != HKWMentionsCreationNetworkStateQuiescent) {
         return;
     }
     self.state = HKWMentionsCreationStateCreatingMention;
@@ -666,7 +668,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
     if (sequence != self.sequenceNumber) {
         // This is a response to an out-of-date request.
         HKWLOG(@"  DEBUG: out-of-date request (seq: %lu, current: %lu)",
-                (unsigned long)sequence, (unsigned long)self.sequenceNumber);
+               (unsigned long)sequence, (unsigned long)self.sequenceNumber);
         return;
     }
     if (self.state == HKWMentionsCreationStateQuiescent && self.searchType != HKWMentionsSearchTypeInitial) {
@@ -921,7 +923,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
     // Create the mention
     id<HKWMentionsEntityProtocol> entity = self.entityArray[(NSUInteger)indexPath.row];
     HKWMentionsAttribute *mention = [HKWMentionsAttribute mentionWithText:[entity entityName]
-                                                                 identifier:[entity entityId]];
+                                                               identifier:[entity entityId]];
     mention.metadata = [entity entityMetadata];
     self.state = HKWMentionsCreationStateQuiescent;
     __strong __auto_type delegate = self.delegate;
@@ -999,7 +1001,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
         return;
     }
     HKW_STATE_LOG(@"  Creation SM Network State Transition: %@ --> %@",
-                   nameForNetworkState(_networkState), nameForNetworkState(networkState));
+                  nameForNetworkState(_networkState), nameForNetworkState(networkState));
     _networkState = networkState;
     if (_networkState == HKWMentionsCreationNetworkStateQuiescent) {
         // Reset the cooldown timer
@@ -1012,7 +1014,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
         return;
     }
     HKW_STATE_LOG(@"  Creation SM Results State Transition: %@ --> %@",
-                   nameForResultsState(_resultsState), nameForResultsState(resultsState));
+                  nameForResultsState(_resultsState), nameForResultsState(resultsState));
     _resultsState = resultsState;
 }
 

--- a/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
@@ -271,9 +271,10 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
     __strong __auto_type delegate = self.delegate;
 
     /**
-     For cases when mentions is triggered when whitespace between control character and word is deleted,
-     for example "@|John"('|'represents cursor), string buffer is not empty but mentions has to stop when control character is deleted.
-     Using isControlCharacterDeleted flag to decide control character deletion for such case.
+     When mentions was originally triggered because the whitespace between a control character and a word was deleted,
+     the cursor is next to the control character (like "@|John", where '|' represents the cursor-state). If the user then deletes the control character,
+     the string buffer will not be empty (it will have "John" in it), but mentions has to stop, because control character is deleted.
+     We use the isControlCharacterDeleted flag to decide what to do in this case of control character deletion.
      */
     BOOL isControlCharacterDeleted = NO;
     if (deleteString.length == 1

--- a/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
@@ -145,7 +145,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
     return sm;
 }
 
-- (void)characterTyped:(unichar)c {
+- (void)characterTyped:(unichar)c previousCharacterIsControl:(BOOL)previousCharacterIsControl {
     BOOL isNewline = [[NSCharacterSet newlineCharacterSet] characterIsMember:c];
     BOOL isWhitespace = [[NSCharacterSet whitespaceCharacterSet] characterIsMember:c];
     __strong __auto_type delegate = self.delegate;
@@ -164,7 +164,10 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
                 return;
             }
     }
-    if ([self.stringBuffer length] == 0 && isWhitespace) {
+    // When whitespace is typed during mention creation state and previous char is control character
+    // then metion creation should to stalled. e.g "@@ " will stop mention current creation.
+    const BOOL shouldCreateNewMentionState = previousCharacterIsControl && isWhitespace;
+    if (([self.stringBuffer length] == 0 && isWhitespace) || shouldCreateNewMentionState) {
         self.state = HKWMentionsCreationStateQuiescent;
         [delegate cancelMentionFromStartingLocation:self.startingLocation];
         return;
@@ -239,7 +242,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
     }
 }
 
-- (void)stringDeleted:(NSString *)deleteString {
+- (void)stringDeleted:(NSString *)deleteString isControlCharacterDeleted:(BOOL)isControlCharacterDeleted {
     // State transition
     NSAssert([deleteString length] > 0, @"Logic error: string to be deleted must not be empty.");
 
@@ -276,6 +279,13 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
             // User not creating a mention right now
             return;
         case HKWMentionsCreationStateCreatingMention:
+            if (isControlCharacterDeleted) {
+                // When user deletes control character during mention creation state, then end mention creation.
+                self.state = HKWMentionsCreationStateQuiescent;
+                [delegate cancelMentionFromStartingLocation:self.startingLocation];
+                return;
+            }
+
             if (deleteStringIsTransient) {
                 // Delete was typed, but for some sort of transient state (e.g. keyboard suggestions); don't do anything
                 return;

--- a/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsCreationStateMachine.m
@@ -145,7 +145,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
     return sm;
 }
 
-- (void)characterTyped:(unichar)c previousCharacterIsControl:(BOOL)previousCharacterIsControl {
+- (void)characterTyped:(unichar)c {
     BOOL isNewline = [[NSCharacterSet newlineCharacterSet] characterIsMember:c];
     BOOL isWhitespace = [[NSCharacterSet whitespaceCharacterSet] characterIsMember:c];
     __strong __auto_type delegate = self.delegate;
@@ -164,9 +164,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsCreationAction) {
                 return;
             }
     }
-    // When whitespace is typed during mention creation state and previous character is control character
-    // then mention creation should end. e.g "@@ " will stop mention current creation.
-    if (([self.stringBuffer length] == 0 || previousCharacterIsControl) && isWhitespace) {
+    if ([self.stringBuffer length] == 0 && isWhitespace) {
         self.state = HKWMentionsCreationStateQuiescent;
         [delegate cancelMentionFromStartingLocation:self.startingLocation];
         return;

--- a/Hakawai/Mentions/HKWMentionsPlugin.m
+++ b/Hakawai/Mentions/HKWMentionsPlugin.m
@@ -998,12 +998,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
             //  is a space/newline preceding, but if this is changed then the state machine must be primed in case there
             //  is a mention right before the mention creation point.
             unichar stackC = deletedChar;
-
-            // This check is used to stop mention creation when control character triggering mentions is deleted.
-            BOOL isControlCharacterDeleted = (precedingChar == 0 || [[NSCharacterSet whitespaceAndNewlineCharacterSet] characterIsMember:precedingChar])
-            && [self.controlCharacterSet characterIsMember:deletedChar];
-
-            [self.creationStateMachine stringDeleted:[NSString stringWithCharacters:&stackC length:1] isControlCharacterDeleted:isControlCharacterDeleted];
+            [self.creationStateMachine stringDeleted:[NSString stringWithCharacters:&stackC length:1]];
             // Get prior character to properly prime start detection state machine
             if (self.state == HKWMentionsStateQuiescent) {
                 // If we're in here, the mention creation ended (and by extension, we moved back to Quiescent)
@@ -1256,23 +1251,11 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
             [self resetCurrentMentionsData];
             self.state = HKWMentionsStateQuiescent;
             break;
-        case HKWMentionsStartDetectionStateCreatingMention: {
-            const BOOL precedingCharacterIsSeparator = [[NSCharacterSet whitespaceAndNewlineCharacterSet] characterIsMember:precedingCharacter]
-            || [[NSCharacterSet punctuationCharacterSet] characterIsMember:precedingCharacter];
-            const BOOL deletedStringFirstCharacterIsControl = deletedString.length > 0
-            ? [self.controlCharacterSet characterIsMember:[deletedString characterAtIndex:0]]
-            : NO;
-
-            BOOL isControlCharacterDeleted = NO;
-            if (precedingCharacterIsSeparator && deletedStringFirstCharacterIsControl) {
-                isControlCharacterDeleted = YES;
-            }
-
-            [self.creationStateMachine stringDeleted:deletedString isControlCharacterDeleted:isControlCharacterDeleted];
+        case HKWMentionsStartDetectionStateCreatingMention:
+            [self.creationStateMachine stringDeleted:deletedString];
             self.nextSelectionChangeShouldBeIgnored = YES;
             self.nextInsertionShouldBeIgnored = YES;
             break;
-        }
         case HKWMentionsStateAboutToSelectMention:
         case HKWMentionsStateSelectedMention:
             [self.startDetectionStateMachine cursorMovedWithCharacterNowPrecedingCursor:precedingCharacter];

--- a/Hakawai/Mentions/HKWMentionsPlugin.m
+++ b/Hakawai/Mentions/HKWMentionsPlugin.m
@@ -864,7 +864,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
         case HKWMentionsStartDetectionStateCreatingMention:
             // Inform the mentions creation state machine that a character was typed. Do not allow the double space to
             //  period auto-substitution while the user is creating a mention.
-            [self.creationStateMachine characterTyped:newChar previousCharacterIsControl:[self.controlCharacterSet characterIsMember:precedingChar]];
+            [self.creationStateMachine characterTyped:newChar];
             if (isSecondSpace) {
                 [self manuallyInsertCharacter:newChar atLocation:location inTextView:parentTextView];
                 self.characterForAdvanceStateForCharacterInsertion = (unichar)0;

--- a/Hakawai/Mentions/HKWMentionsPlugin.m
+++ b/Hakawai/Mentions/HKWMentionsPlugin.m
@@ -128,9 +128,9 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
  character being inserted. Otherwise, it contains the NULL character, 0.
 
  This property is intended to allow the data-retrieved callback code to determine whether the callback was called
- synchronously or asynchronously, and therefore determine which character to use to determine whether mentions creation, 
+ synchronously or asynchronously, and therefore determine which character to use to determine whether mentions creation,
  if cancelled, should be allowed to immediately restart.
- 
+
  (If the callback was made asynchronously, then the text in the text view should be used to determine the last character
  typed. If the callback was made synchronously, then the character in this property should be used to determine whether
  or not to allow immediate restart. However, sometimes the callback will be deferred until the next runloop anyways, so
@@ -425,8 +425,8 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
                                                   // This won't ever happen if the proper library methods are used to
                                                   //  work with mentions.
                                                   HKWLOG(@"WARNING: mentionsAttributesInAttributedString found \
-                                                          invalid data attached to a mentions attribute. Only use the \
-                                                          methods provided to work with mentions attributes.");
+                                                         invalid data attached to a mentions attribute. Only use the \
+                                                         methods provided to work with mentions attributes.");
                                                   continue;
                                               }
                                               HKWMentionsAttribute *attributeData = (HKWMentionsAttribute *)object;
@@ -466,7 +466,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
                              edgeInsets:(UIEdgeInsets)edgeInsets {
     if (!self.parentTextView) {
         HKWLOG(@"WARNING! No parent text view set. Don't call calculatedChooserViewFrameForMode until the mentions \
-                plug-in has been registered to an editor text view.");
+               plug-in has been registered to an editor text view.");
     }
     CGRect frame = [self.creationStateMachine frameForMode:mode];
     if (!CGRectIsNull(frame)) {
@@ -498,7 +498,10 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
     for (NSUInteger i=0; i<[string length]; i++) {
         unichar c = [string characterAtIndex:i];
         if ([invalidChars characterIsMember:c]) { return NO; }
-        if (self.controlCharacterSet && [self.controlCharacterSet characterIsMember:c]) { return NO; }
+        // We should allow insertion of control characters as a valid mention string
+        if (!HKWTextView.enableKoreanMentionsFix) {
+            if (self.controlCharacterSet && [self.controlCharacterSet characterIsMember:c]) { return NO; }
+        }
     }
     return YES;
 }
@@ -842,6 +845,12 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
     BOOL isSecondSpace = (location > 1) && (precedingChar == ' ' && newChar == ' ');
     switch (self.state) {
         case HKWMentionsStateQuiescent: {
+            if (HKWTextView.enableKoreanMentionsFix) {
+                // Update the location of the selected range for this insertion here
+                // (since the text view will already be updated when utilizing the text storage delegate in the korean mentions fix)
+                // This should replace other settings of this range when the fix is ramped
+                parentTextView.selectedRange = NSMakeRange(location, parentTextView.selectedRange.length);
+            }
             // Inform the start detection state machine that a character was inserted. Also, override the double space
             //  to period auto-substitution if the substitution would place a period right after a preceding mention.
             [self.startDetectionStateMachine characterTyped:newChar asInsertedCharacter:NO previousCharacter:precedingChar];
@@ -930,7 +939,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
             if (location > 0) {
                 NSRange mentionRange;
                 HKWMentionsAttribute *precedingMention = [self mentionAttributePrecedingLocation:location
-                                                                                            range:&mentionRange];
+                                                                                           range:&mentionRange];
                 if (precedingMention) {
                     // There is a mention right before the cursor's current position.
                     // If the user taps 'delete' again, they will actually select the mention.
@@ -1022,7 +1031,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
                                                                  [trimmedString length]);
                 // Move the cursor into position.
                 parentTextView.selectedRange = NSMakeRange(self.currentlySelectedMentionRange.location + [trimmedString length],
-                                                                0);
+                                                           0);
                 location = parentTextView.selectedRange.location;
 
                 // Notify the plugin's state change delegate that a mention was trimmed.
@@ -1049,8 +1058,8 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
                 [self stripCustomAttributesFromTypingAttributes];
                 parentTextView.selectedRange = NSMakeRange(locationAfterDeletion, 0);
 
-				// Store current mention before reset
-				HKWMentionsAttribute *currentMention = self.currentlySelectedMention;
+                // Store current mention before reset
+                HKWMentionsAttribute *currentMention = self.currentlySelectedMention;
                 [self resetCurrentMentionsData];
                 self.state = HKWMentionsStateQuiescent;
                 // Update selection state
@@ -1063,7 +1072,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
                 if (locationAfterDeletion > 0) {
                     NSRange mentionRange;
                     HKWMentionsAttribute *precedingMention = [self mentionAttributePrecedingLocation:locationAfterDeletion
-                                                                                                range:&mentionRange];
+                                                                                               range:&mentionRange];
                     if (precedingMention) {
                         // There is a mention right before the cursor's current position.
                         // If the user taps 'delete' again, they will actually select the mention.
@@ -1178,21 +1187,40 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
             }
             break;
         }
-        case HKWMentionsStartDetectionStateCreatingMention:
+        case HKWMentionsStartDetectionStateCreatingMention: {
             // If one or more characters are inserted automatically (e.g. pasting in text, certain types of keyboards),
-            //  insert the text, but only if it's valid. Otherwise, treat it as if the cursor moved and the mention
-            //  creation process was cancelled.
-            if ([self stringValidForMentionsCreation:text]) {
-                self.characterForAdvanceStateForCharacterInsertion = [text characterAtIndex:[text length] - 1];
-                [self.creationStateMachine validStringInserted:text];
-                self.characterForAdvanceStateForCharacterInsertion = (unichar)0;
-                break;
+            // insert the text, but only if it's valid.
+            // Begin a mention if the control character was replaced by another.
+            // Otherwise, treat it as if the cursor moved and the mention  creation process was cancelled.
+            BOOL didBeginMentionsCreation = NO;
+            if (HKWTextView.enableKoreanMentionsFix) {
+                if (text && [text length] > 0) {
+                    unichar firstReplacementTextCharacter = [text characterAtIndex:0];
+                    BOOL isReplacementTextMention = [self.controlCharacterSet characterIsMember:firstReplacementTextCharacter];
+                    if (isReplacementTextMention && self.resumeMentionsPriorPosition == range.location) {
+                        // If we are replacing a mention string with a mentions string, begin the mention
+                        [self beginMentionsCreationWithString:[text substringFromIndex:1]
+                                                   atLocation:range.location
+                                        usingControlCharacter:YES
+                                             controlCharacter:firstReplacementTextCharacter];
+                        didBeginMentionsCreation = YES;
+                    }
+                }
             }
-            else {
-                [self.creationStateMachine cursorMoved];
-                self.state = HKWMentionsStateQuiescent;
+            if (!didBeginMentionsCreation) {
+                if ([self stringValidForMentionsCreation:text]) {
+                    self.characterForAdvanceStateForCharacterInsertion = [text characterAtIndex:[text length] - 1];
+                    [self.creationStateMachine validStringInserted:text];
+                    self.characterForAdvanceStateForCharacterInsertion = (unichar)0;
+                    break;
+                }
+                else {
+                    [self.creationStateMachine cursorMoved];
+                    self.state = HKWMentionsStateQuiescent;
+                }
             }
             break;
+        }
         case HKWMentionsStateAboutToSelectMention:
             // Leave the 'about to select' state and resume scanning
             self.state = HKWMentionsStateQuiescent;
@@ -1417,7 +1445,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
             [self assertMentionsDataExists];
             NSRange mentionRange;
             HKWMentionsAttribute *precedingMention = [self mentionAttributePrecedingLocation:location
-                                                                                                range:&mentionRange];
+                                                                                       range:&mentionRange];
             if (!precedingMention) {
                 // User moved cursor away from the current mention and to a position with no mention
                 [self toggleMentionsFormattingAtRange:self.currentlySelectedMentionRange selected:NO];
@@ -1462,15 +1490,19 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
     if (self.state == HKWMentionsStartDetectionStateCreatingMention) {
         [self.creationStateMachine cancelMentionCreation];
     } else {
-       self.state = HKWMentionsStateQuiescent;
+        self.state = HKWMentionsStateQuiescent;
     }
 
     [self.startDetectionStateMachine resetStateUsingString:[textView.text copy]];
     [self resetAuxiliaryState];
 }
 
-- (void)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text isInsertion:(BOOL)isInsertion {
-    BOOL isCreatingOrStartingMention = self.state == HKWMentionsStartDetectionStateCreatingMention || [self isStringControlCharacter:text];
+- (void)textView:(UITextView *)textView
+shouldChangeTextInRange:(NSRange)range
+      changeText:(NSString *)text
+     isInsertion:(BOOL)isInsertion
+  previousLength:(NSUInteger)previousLength {
+    BOOL isCreatingOrStartingMention = self.state == HKWMentionsStartDetectionStateCreatingMention || ([self isStringControlCharacter:text] && isInsertion);
     if (!isCreatingOrStartingMention) {
         // Only implement Korean mentions fix when creating or starting mentions
         // We will revisit a longer term alignment of using the fix in non-mentions cases, after we ramp the mentions fix
@@ -1479,6 +1511,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
     self.suppressSelectionChangeNotifications = YES;
     __strong __auto_type parentTextView = self.parentTextView;
     unichar precedingChar = [parentTextView characterPrecedingLocation:(NSInteger)range.location];
+    self.previousTextLength = previousLength;
 
     if (self.nextInsertionShouldBeIgnored) {
         self.nextInsertionShouldBeIgnored = NO;
@@ -1525,13 +1558,6 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
         // Replacing text (e.g. pasting, autocorrect, etc)
         [self advanceStateForSelectionChanged:NSMakeRange(range.location + ([text length] - range.length), 0) replacementText:text];
     }
-    // Since text view has already updated when text storage delegate is called, determine previous length programatically
-    // via the type and size of the change, and the current state
-    if (isInsertion) {
-        self.previousTextLength = textView.text.length - text.length;
-    } else {
-        self.previousTextLength = textView.text.length + text.length;
-    }
     self.previousSelectionRange = textView.selectedRange;
     [self stripCustomAttributesFromTypingAttributes];
     self.suppressSelectionChangeNotifications = NO;
@@ -1545,7 +1571,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
 }
 
 - (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text {
-    BOOL isCreatingOrStartingMention = self.state == HKWMentionsStartDetectionStateCreatingMention || [self isStringControlCharacter:text];
+    BOOL isCreatingOrStartingMention = self.state == HKWMentionsStartDetectionStateCreatingMention || ([self isStringControlCharacter:text] && [text length] > 0);
     // If korean mentions fix is on, don't respond to text edits during or at the beginning of mention creation in this method
     // do so only through the text storage delegate
     if (HKWTextView.enableKoreanMentionsFix && isCreatingOrStartingMention) {
@@ -2129,10 +2155,10 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
         }
     }
     else {
-      // Tell state change delegate that the chooser view has been closed.
-      if ([stateChangeDelegate respondsToSelector:@selector(mentionsPluginDeactivatedChooserView:)]) {
-        [stateChangeDelegate mentionsPluginDeactivatedChooserView:self];
-      }
+        // Tell state change delegate that the chooser view has been closed.
+        if ([stateChangeDelegate respondsToSelector:@selector(mentionsPluginDeactivatedChooserView:)]) {
+            [stateChangeDelegate mentionsPluginDeactivatedChooserView:self];
+        }
     }
 }
 

--- a/Hakawai/Mentions/HKWMentionsPlugin.m
+++ b/Hakawai/Mentions/HKWMentionsPlugin.m
@@ -845,17 +845,19 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
     BOOL isSecondSpace = (location > 1) && (precedingChar == ' ' && newChar == ' ');
     switch (self.state) {
         case HKWMentionsStateQuiescent: {
+            // Word following typed character would be used to trigger matching mentions menu when possible.
+            NSString *wordFollowingTypedCharacter;
             if (HKWTextView.enableKoreanMentionsFix) {
                 // Update the location of the selected range for this insertion here
                 // (since the text view will already be updated when utilizing the text storage delegate in the korean mentions fix)
                 // This should replace other settings of this range when the fix is ramped
                 parentTextView.selectedRange = NSMakeRange(location, parentTextView.selectedRange.length);
+                wordFollowingTypedCharacter = [HKWMentionsStartDetectionStateMachine wordAfterLocation:location text:parentTextView.textStateBeforeDeletion];
+            } else {
+                wordFollowingTypedCharacter = [HKWMentionsStartDetectionStateMachine wordAfterLocation:location text:parentTextView.text];
             }
             // Inform the start detection state machine that a character was inserted. Also, override the double space
             //  to period auto-substitution if the substitution would place a period right after a preceding mention.
-
-            // Word following typed character would be used to trigger matching mentions menu when possible.
-            NSString *wordFollowingTypedCharacter = [HKWMentionsStartDetectionStateMachine wordAfterLocation:location text:parentTextView.text];
             [self.startDetectionStateMachine characterTyped:newChar
                                         asInsertedCharacter:NO
                                           previousCharacter:precedingChar

--- a/Hakawai/Mentions/HKWMentionsPlugin.m
+++ b/Hakawai/Mentions/HKWMentionsPlugin.m
@@ -844,7 +844,10 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
         case HKWMentionsStateQuiescent: {
             // Inform the start detection state machine that a character was inserted. Also, override the double space
             //  to period auto-substitution if the substitution would place a period right after a preceding mention.
-            [self.startDetectionStateMachine characterTyped:newChar asInsertedCharacter:NO previousCharacter:precedingChar];
+
+            // When control character is inserted before existing word in text view, then query mention with that word.
+            NSString *textAfterControlCharacter = [HKWMentionsStartDetectionStateMachine wordAfterLocation:location text:parentTextView.text];
+            [self.startDetectionStateMachine characterTyped:newChar asInsertedCharacter:NO previousCharacter:precedingChar queryMentionForText:textAfterControlCharacter];
             NSRange r;
             id mentionTwoPreceding = [self mentionAttributePrecedingLocation:(location-1) range:&r];
             BOOL shouldSuppress = (mentionTwoPreceding != nil) && (r.location + r.length == location-1);
@@ -858,7 +861,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
         case HKWMentionsStartDetectionStateCreatingMention:
             // Inform the mentions creation state machine that a character was typed. Do not allow the double space to
             //  period auto-substitution while the user is creating a mention.
-            [self.creationStateMachine characterTyped:newChar];
+            [self.creationStateMachine characterTyped:newChar previousCharacterIsControl:[self.controlCharacterSet characterIsMember:precedingChar]];
             if (isSecondSpace) {
                 [self manuallyInsertCharacter:newChar atLocation:location inTextView:parentTextView];
                 self.characterForAdvanceStateForCharacterInsertion = (unichar)0;
@@ -870,7 +873,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
             //  insert a new character and continue in the quiescent state. Do not allow auto-substitution.
             self.state = HKWMentionsStateQuiescent;
             [self resetCurrentMentionsData];
-            [self.startDetectionStateMachine characterTyped:newChar asInsertedCharacter:NO previousCharacter:precedingChar];
+            [self.startDetectionStateMachine characterTyped:newChar asInsertedCharacter:NO previousCharacter:precedingChar queryMentionForText:nil];
             if (isSecondSpace) {
                 [self manuallyInsertCharacter:newChar atLocation:location inTextView:parentTextView];
                 self.characterForAdvanceStateForCharacterInsertion = (unichar)0;
@@ -892,7 +895,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
             [self resetCurrentMentionsData];
             self.state = HKWMentionsStateQuiescent;
             self.characterForAdvanceStateForCharacterInsertion = (unichar)0;
-            [self.startDetectionStateMachine characterTyped:newChar asInsertedCharacter:YES previousCharacter:precedingChar];
+            [self.startDetectionStateMachine characterTyped:newChar asInsertedCharacter:YES previousCharacter:precedingChar queryMentionForText:nil];
             returnValue = NO;
             break;
         case HKWMentionsStateLosingFocus:
@@ -923,7 +926,9 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
     switch (self.state) {
         case HKWMentionsStateQuiescent: {
             [self.startDetectionStateMachine deleteTypedCharacter:deletedChar
-                                  withCharacterNowPrecedingCursor:precedingChar];
+                                  withCharacterNowPrecedingCursor:precedingChar
+                                                         location:location
+                                                     textViewText:parentTextView.text];
             self.nextSelectionChangeShouldBeIgnored = YES;
 
             // Look for a mention
@@ -987,7 +992,17 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
             //  is a space/newline preceding, but if this is changed then the state machine must be primed in case there
             //  is a mention right before the mention creation point.
             unichar stackC = deletedChar;
-            [self.creationStateMachine stringDeleted:[NSString stringWithCharacters:&stackC length:1]];
+
+            // This check is used to stop mention creation when control character is deleted.
+            // Also check if second previous character is control, it YES then don't stop mention creation.
+            BOOL secondPreviousCaracterIsControl = NO;
+            if (location >= 1) {
+                unichar secondPreviousCharacter = [parentTextView.text characterAtIndex:location - 1];
+                secondPreviousCaracterIsControl = [self.controlCharacterSet characterIsMember:secondPreviousCharacter];
+            }
+            BOOL isControlCharacterDeleted = !secondPreviousCaracterIsControl && [self.controlCharacterSet characterIsMember:deletedChar];
+
+            [self.creationStateMachine stringDeleted:[NSString stringWithCharacters:&stackC length:1] isControlCharacterDeleted:isControlCharacterDeleted];
             // Get prior character to properly prime start detection state machine
             if (self.state == HKWMentionsStateQuiescent) {
                 // If we're in here, the mention creation ended (and by extension, we moved back to Quiescent)
@@ -1134,8 +1149,7 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
                 self.previousSelectionRange = newSelectionRange;
                 self.previousTextLength = [[parentTextView text] length];
 
-                [self.startDetectionStateMachine characterTyped:[text characterAtIndex:0] asInsertedCharacter:YES previousCharacter:precedingChar];
-
+                [self.startDetectionStateMachine characterTyped:[text characterAtIndex:0] asInsertedCharacter:YES previousCharacter:precedingChar queryMentionForText:nil];
                 // Manually notify external delegate that the textView changed
                 id<HKWTextViewDelegate> externalDelegate = parentTextView.externalDelegate;
                 if ([externalDelegate respondsToSelector:@selector(textViewDidChange:)]) {
@@ -1238,11 +1252,22 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
             [self resetCurrentMentionsData];
             self.state = HKWMentionsStateQuiescent;
             break;
-        case HKWMentionsStartDetectionStateCreatingMention:
-            [self.creationStateMachine stringDeleted:deletedString];
+        case HKWMentionsStartDetectionStateCreatingMention: {
+            const BOOL precedingCharacterIsWhitepace = [[NSCharacterSet whitespaceAndNewlineCharacterSet] characterIsMember:precedingCharacter];
+            const BOOL deletedStringFirstCharacterIsControl = deletedString.length > 0
+            ? [self.controlCharacterSet characterIsMember:[deletedString characterAtIndex:0]]
+            : NO;
+
+            BOOL isControlCharacterDeleted = NO;
+            if (precedingCharacterIsWhitepace && deletedStringFirstCharacterIsControl) {
+                isControlCharacterDeleted = YES;
+            }
+
+            [self.creationStateMachine stringDeleted:deletedString isControlCharacterDeleted:isControlCharacterDeleted];
             self.nextSelectionChangeShouldBeIgnored = YES;
             self.nextInsertionShouldBeIgnored = YES;
             break;
+        }
         case HKWMentionsStateAboutToSelectMention:
         case HKWMentionsStateSelectedMention:
             [self.startDetectionStateMachine cursorMovedWithCharacterNowPrecedingCursor:precedingCharacter];
@@ -1781,7 +1806,12 @@ typedef NS_ENUM(NSInteger, HKWMentionsState) {
     UIColor *parentColor = parentTextView.textColorSetByApp;
     NSAssert(self.mentionUnselectedAttributes != nil, @"Error! Mention attribute dictionaries should never be nil.");
     NSDictionary *unselectedAttributes = self.mentionUnselectedAttributes;
-    NSRange rangeToTransform = NSMakeRange(location, currentLocation - location);
+
+    // When control char is inserted before word and user select mention for that word,
+    // then we want to replace word after control char with mention text.
+    // e.g "hey @|john" will be replaced as "hey John Doe". '|' indicates cursor.
+    NSString *const wordAfterCurrentLocation = [HKWMentionsStartDetectionStateMachine wordAfterLocation:currentLocation text:parentTextView.text];
+    NSRange rangeToTransform = NSMakeRange(location, currentLocation + wordAfterCurrentLocation.length - location);
 
     /*
      When the textview text that matches the mention text is not the first part of the mention text,

--- a/Hakawai/Mentions/HKWMentionsStartDetectionStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsStartDetectionStateMachine.m
@@ -203,12 +203,16 @@ withCharacterNowPrecedingCursor:(unichar)precedingChar
 
     switch (self.state) {
         case HKWMentionsStartDetectionStateQuiescentReady: {
+            // Mention can be triggered upon character deletion:
+            // 1. when deleted character location is greater than 1 -> When previous character is a control character and character before previous character is a separator.
+            // 2. when deleted character location is 1 -> If preceding character is a control character
+            // 3. when deleted character location is 0 -> Does not trigger mentions
             BOOL canCreateMention = NO;
             if (location > 1 && textViewText.length > location - 2) {
                 const unichar characterBeforePrecedingChar = [textViewText characterAtIndex:location - 2];
                 canCreateMention = [HKWMentionsStartDetectionStateMachine.separatorSet characterIsMember:characterBeforePrecedingChar]
                 && precedingCharacterType == CharacterTypeControlCharacter;
-            } else if (location > 0 && precedingCharacterType == CharacterTypeControlCharacter) {
+            } else if (precedingCharacterType == CharacterTypeControlCharacter) {
                 canCreateMention = YES;
             }
             // If user deletes white-space or separators between control character and word, then query mention with word next to whitepace.

--- a/Hakawai/Mentions/HKWMentionsStartDetectionStateMachine.m
+++ b/Hakawai/Mentions/HKWMentionsStartDetectionStateMachine.m
@@ -206,7 +206,7 @@ withCharacterNowPrecedingCursor:(unichar)precedingChar
             // Mention can be triggered upon character deletion:
             // 1. when deleted character location is greater than 1 -> When previous character is a control character and character before previous character is a separator.
             // 2. when deleted character location is 1 -> If preceding character is a control character
-            // 3. when deleted character location is 0 -> Does not trigger mentions
+            // (NOTE: When deleted character location is 0, mentions is never triggered)
             BOOL canCreateMention = NO;
             if (location > 1 && textViewText.length > location - 2) {
                 const unichar characterBeforePrecedingChar = [textViewText characterAtIndex:location - 2];
@@ -271,7 +271,7 @@ withCharacterNowPrecedingCursor:(unichar)precedingChar
             self.charactersSinceLastWhitespace = 0;
             if (currentCharacterType == CharacterTypeSeparator || currentCharacterType == CharacterTypeControlCharacter) {
                 // The user moved the cursor to the beginning of the text region, or right after a newline or whitespace or punctuation
-                //  character. This puts the user in the ready state.
+                //  character or control character. This puts the user in the ready state.
                 self.state = HKWMentionsStartDetectionStateQuiescentReady;
             }
             else if (currentCharacterType == CharacterTypeNormal) {

--- a/Hakawai/Mentions/_HKWMentionsCreationStateMachine.h
+++ b/Hakawai/Mentions/_HKWMentionsCreationStateMachine.h
@@ -128,7 +128,7 @@
 /*!
  Inform the state machine that a character or string was deleted from the text view.
  */
-- (void)stringDeleted:(NSString *)deleteString isControlCharacterDeleted:(BOOL)isControlCharacterDeleted;
+- (void)stringDeleted:(NSString *)deleteString;
 
 /*!
  Inform the state machine that the cursor was moved from its prior position and is now in insertion mode.

--- a/Hakawai/Mentions/_HKWMentionsCreationStateMachine.h
+++ b/Hakawai/Mentions/_HKWMentionsCreationStateMachine.h
@@ -117,7 +117,7 @@
 /*!
  Inform the state machine that a single character was typed by the user into the text view.
  */
-- (void)characterTyped:(unichar)c;
+- (void)characterTyped:(unichar)c previousCharacterIsControl:(BOOL)previousCharacterIsControl;
 
 /*!
  Inform the state machine that a valid string was inserted into the text view (no spaces, newlines, or forbidden
@@ -128,7 +128,7 @@
 /*!
  Inform the state machine that a character or string was deleted from the text view.
  */
-- (void)stringDeleted:(NSString *)deleteString;
+- (void)stringDeleted:(NSString *)deleteString isControlCharacterDeleted:(BOOL)isControlCharacterDeleted;
 
 /*!
  Inform the state machine that the cursor was moved from its prior position and is now in insertion mode.

--- a/Hakawai/Mentions/_HKWMentionsCreationStateMachine.h
+++ b/Hakawai/Mentions/_HKWMentionsCreationStateMachine.h
@@ -117,7 +117,7 @@
 /*!
  Inform the state machine that a single character was typed by the user into the text view.
  */
-- (void)characterTyped:(unichar)c previousCharacterIsControl:(BOOL)previousCharacterIsControl;
+- (void)characterTyped:(unichar)c;
 
 /*!
  Inform the state machine that a valid string was inserted into the text view (no spaces, newlines, or forbidden

--- a/Hakawai/Mentions/_HKWMentionsStartDetectionStateMachine.h
+++ b/Hakawai/Mentions/_HKWMentionsStartDetectionStateMachine.h
@@ -94,12 +94,12 @@
  Inform the state machine that a character was typed by the user into the text view.
  \param inserted    whether the character was already inserted into the text view's text buffer
  */
-- (void)characterTyped:(unichar)c asInsertedCharacter:(BOOL)inserted previousCharacter:(unichar)previousCharacter;
+- (void)characterTyped:(unichar)c asInsertedCharacter:(BOOL)inserted previousCharacter:(unichar)previousCharacter queryMentionForText:(NSString *)queryMentionForText;
 
 /*!
  Inform the state machine that a character was deleted by the user from the text view.
  */
-- (void)deleteTypedCharacter:(unichar)deletedChar withCharacterNowPrecedingCursor:(unichar)precedingChar;
+- (void)deleteTypedCharacter:(unichar)deletedChar withCharacterNowPrecedingCursor:(unichar)precedingChar location:(NSUInteger)location textViewText:(NSString *)textViewText;
 
 /*!
  Inform the state machine that the cursor was moved from its prior position and is now in insertion mode.
@@ -124,5 +124,10 @@
  Inform the state machine that the attached control view has reset it's state, and now represents the specified string
  */
 -(void) resetStateUsingString:(NSString *)string;
+
+/*!
+ Return characters after given location till whitespace is encountered.
+ */
++ (NSString *)wordAfterLocation:(NSUInteger)location text:(NSString *)text;
 
 @end

--- a/Hakawai/Mentions/_HKWMentionsStartDetectionStateMachine.h
+++ b/Hakawai/Mentions/_HKWMentionsStartDetectionStateMachine.h
@@ -104,6 +104,10 @@ wordFollowingTypedCharacter:(NSString *)wordFollowingTypedCharacter;
 
 /*!
  Inform the state machine that a character was deleted by the user from the text view.
+ \param deletedChar                         Character to be deleted
+ \param precedingChar                       Character before character to be deleted
+ \param location                            Location of character to be deleted
+ \param textViewText                        Text displayed by text view
  */
 - (void)deleteTypedCharacter:(unichar)deletedChar
 withCharacterNowPrecedingCursor:(unichar)precedingChar

--- a/Hakawai/Mentions/_HKWMentionsStartDetectionStateMachine.h
+++ b/Hakawai/Mentions/_HKWMentionsStartDetectionStateMachine.h
@@ -94,12 +94,15 @@
  Inform the state machine that a character was typed by the user into the text view.
  \param inserted    whether the character was already inserted into the text view's text buffer
  */
-- (void)characterTyped:(unichar)c asInsertedCharacter:(BOOL)inserted previousCharacter:(unichar)previousCharacter queryMentionForText:(NSString *)queryMentionForText;
+- (void)characterTyped:(unichar)c asInsertedCharacter:(BOOL)inserted previousCharacter:(unichar)previousCharacter nextString:(NSString *)nextString;
 
 /*!
  Inform the state machine that a character was deleted by the user from the text view.
  */
-- (void)deleteTypedCharacter:(unichar)deletedChar withCharacterNowPrecedingCursor:(unichar)precedingChar location:(NSUInteger)location textViewText:(NSString *)textViewText;
+- (void)deleteTypedCharacter:(unichar)deletedChar
+withCharacterNowPrecedingCursor:(unichar)precedingChar
+                    location:(NSUInteger)location
+                textViewText:(NSString *)textViewText;
 
 /*!
  Inform the state machine that the cursor was moved from its prior position and is now in insertion mode.

--- a/Hakawai/Mentions/_HKWMentionsStartDetectionStateMachine.h
+++ b/Hakawai/Mentions/_HKWMentionsStartDetectionStateMachine.h
@@ -92,9 +92,15 @@
 
 /*!
  Inform the state machine that a character was typed by the user into the text view.
- \param inserted    whether the character was already inserted into the text view's text buffer
+ \param c                                   Character typed
+ \param inserted                            Whether the character was already inserted into the text view's text buffer
+ \param previousCharacter                   Character preceding typed character
+ \param wordFollowingTypedCharacter         Word following the typed character
  */
-- (void)characterTyped:(unichar)c asInsertedCharacter:(BOOL)inserted previousCharacter:(unichar)previousCharacter nextString:(NSString *)nextString;
+- (void)characterTyped:(unichar)c
+   asInsertedCharacter:(BOOL)inserted
+     previousCharacter:(unichar)previousCharacter
+wordFollowingTypedCharacter:(NSString *)wordFollowingTypedCharacter;
 
 /*!
  Inform the state machine that a character was deleted by the user from the text view.


### PR DESCRIPTION
Editing the mention should trigger the typeahead again

- On removal of whitespace between control character and typed in string, it should trigger mention again
- Updated state machine, to update the flow to trigger mention

Note: The base branch is aniyati/Hakawai/PunctuationMention to exclude the changes from that branch from the diff.